### PR TITLE
Adding ability to manually specify asset type

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,15 @@ The available options are:
 
   Specifies the file extensions to use to determine if assets are style assets. Default is `['.css']`.
 
-- `assets`: `string` or `array`
+- `assets`: `string` or `array` or `object`
 
   Assets that will be output into your html-webpack-plugin template.
 
-  Only assets ending in one of the `jsExtenions` or `cssExtensions` are allowed. The presence of assets that do not end in these extensions will cause an error.
+  To specify just one asset, simply pass a string or object. To specify multiple, pass an array of strings or objects.
+
+  If the asset path ends in one of the `jsExtensions` or `cssExtensions` values, simply use a string value.
+
+  If the asset does not have a valid extension, you can instead pass an object with properties `path` and `type`, where `path` is the asset href/src and `type` is one of `js` or `css`.
 
 - `append`: `boolean`
 
@@ -138,6 +142,27 @@ plugins: [
     assets: ['css/bootstrap.min.css', 'css/bootstrap-theme.min.css'],
     append: false,
     publicPath: 'myPublicPath/'
+  })
+]
+```
+
+Manually specifying asset types :
+
+```javascript
+plugins: [
+  new CopyWebpackPlugin([
+    { from: 'node_modules/bootstrap/dist/css', to: 'css/'},
+    { from: 'node_modules/bootstrap/dist/fonts', to: 'fonts/'}
+  ]),
+  new HtmlWebpackPlugin(),
+  new HtmlWebpackIncludeAssetsPlugin({
+    assets: [
+      '/css/bootstrap.min.css',
+      '/css/bootstrap-theme.min.css',
+      { path: 'https://fonts.googleapis.com/css?family=Material+Icons', type: 'css' }
+    ],
+    append: false,
+    publicPath: ''
   })
 ]
 ```

--- a/index.js
+++ b/index.js
@@ -95,16 +95,20 @@ function HtmlWebpackIncludeAssetsPlugin (options) {
   }
   var assetCount = assets.length;
   var asset;
+  var assetPath;
   for (var i = 0; i < assetCount; i++) {
     asset = assets[i];
-    if (isString(asset)) {
-      assert(hasExtensions(asset, jsExtensions) || hasExtensions(asset, cssExtensions),
+    if (isString(asset) || (isObject(asset) && !asset.type)) {
+      assetPath = isString(asset) ? asset : asset.path;
+      assert(isString(assetPath),
+        'HtmlWebpackIncludeAssetsPlugin options assets key array objects must contain a string path property (' + assetPath + ')');
+      assert(hasExtensions(assetPath, jsExtensions) || hasExtensions(assetPath, cssExtensions),
         'HtmlWebpackIncludeAssetsPlugin options assets key array should not contain strings not ending with the js or css extensions (' + asset + ')');
     } else {
       assert(isObject(asset), 'HtmlWebpackIncludeAssetsPlugin options assets key array must contain only strings and objects (' + asset + ')');
       assert(isString(asset.path),
         'HtmlWebpackIncludeAssetsPlugin options assets key array objects must contain a string path property (' + asset.path + ')');
-      assert(isOneOf(asset.type, [null, undefined, 'js', 'css']),
+      assert(isOneOf(asset.type, ['js', 'css']),
         'HtmlWebpackIncludeAssetsPlugin options assets key array objects must contain a string type property set to either `js` or `css` (' + asset.type + ')');
     }
   }

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function HtmlWebpackIncludeAssetsPlugin (options) {
       assert(isObject(asset), 'HtmlWebpackIncludeAssetsPlugin options assets key array must contain only strings and objects (' + asset + ')');
       assert(isString(asset.path),
         'HtmlWebpackIncludeAssetsPlugin options assets key array objects must contain a string path property (' + asset.path + ')');
-      assert(isOneOf(asset.type, ['js', 'css']),
+      assert(isOneOf(asset.type, [null, undefined, 'js', 'css']),
         'HtmlWebpackIncludeAssetsPlugin options assets key array objects must contain a string type property set to either `js` or `css` (' + asset.type + ')');
     }
   }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var defaultOptions = {
 };
 
 function isObject (v) {
-  return v !== null && v !== undefined && typeof v === 'object';
+  return v !== null && v !== undefined && typeof v === 'object' && !isArray(v);
 }
 
 function isBoolean (v) {
@@ -46,14 +46,14 @@ function hasExtensions (v, extensions) {
   return found;
 }
 
-function matchesEnum (v, values) {
+function isOneOf (v, values) {
   return values.indexOf(v) !== -1;
 }
 
 function HtmlWebpackIncludeAssetsPlugin (options) {
   assert(isObject(options), 'HtmlWebpackIncludeAssetsPlugin options are required');
   var assets;
-  if (isString(options.assets)) {
+  if (isString(options.assets) || isObject(options.assets)) {
     assets = [options.assets];
   } else {
     assets = options.assets;
@@ -104,7 +104,7 @@ function HtmlWebpackIncludeAssetsPlugin (options) {
       assert(isObject(asset), 'HtmlWebpackIncludeAssetsPlugin options assets key array must contain only strings and objects (' + asset + ')');
       assert(isString(asset.path),
         'HtmlWebpackIncludeAssetsPlugin options assets key array objects must contain a string path property (' + asset.path + ')');
-      assert(matchesEnum(asset.type, ['js', 'css']),
+      assert(isOneOf(asset.type, ['js', 'css']),
         'HtmlWebpackIncludeAssetsPlugin options assets key array objects must contain a string type property set to either `js` or `css` (' + asset.type + ')');
     }
   }
@@ -173,8 +173,8 @@ HtmlWebpackIncludeAssetsPlugin.prototype.apply = function (compiler) {
       var jsAssets = [];
       var cssAssets = [];
       for (var i = 0; i < includeCount; i++) {
-        includeAssetPath = typeof includeAssets[i] === 'string' ? includeAssets[i] : includeAssets[i].path;
-        includeAssetType = typeof includeAssets[i] === 'object' ? includeAssets[i].type : null;
+        includeAssetPath = isString(includeAssets[i]) ? includeAssets[i] : includeAssets[i].path;
+        includeAssetType = isObject(includeAssets[i]) ? includeAssets[i].type : null;
         includeAsset = includeAssetPrefix + includeAssetPath + includeAssetHash;
         if ((includeAssetType && includeAssetType === 'js') || hasExtensions(includeAsset, jsExtensions)) {
           if (assets.js.indexOf(includeAsset) === -1 && jsAssets.indexOf(includeAsset) === -1) {

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -92,6 +92,22 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
       done();
     });
 
+    it('should throw an error if any of the asset options are objects without a type property that cannot be inferred', function (done) {
+      var theFunction = function () {
+        return new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.js', { path: 'pathWithoutExtension' }, 'bar.css'], append: false });
+      };
+      expect(theFunction).toThrowError(/(options assets key array should not contain strings not ending with the js or css extensions)/);
+      done();
+    });
+
+    it('should not throw an error if any of the asset options are objects without a type property that can be inferred', function (done) {
+      var theFunction = function () {
+        return new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.js', { path: 'pathWithExtension.js' }, 'bar.css'], append: false });
+      };
+      expect(theFunction).not.toThrowError();
+      done();
+    });
+
     it('should throw an error if the jsExtensions is not an array or string', function (done) {
       var theFunction = function () {
         return new HtmlWebpackIncludeAssetsPlugin({ assets: [], append: false, jsExtensions: 123 });
@@ -376,7 +392,7 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
         plugins: [
           new ExtractTextPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
-          new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.css', 'bar.css'], append: true, publicPath: false })
+          new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.css', 'bar.css', { path: 'baz.css' }], append: true, publicPath: false })
         ]
       }, function (err, result) {
         expect(err).toBeFalsy();
@@ -386,14 +402,16 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           expect(er).toBeFalsy();
           var $ = cheerio.load(data);
           expect($('script').length).toBe(2);
-          expect($('link').length).toBe(3);
+          expect($('link').length).toBe(4);
           expect($('script[src="style.js"]').toString()).toBe('<script type="text/javascript" src="style.js"></script>');
           expect($('script[src="app.js"]').toString()).toBe('<script type="text/javascript" src="app.js"></script>');
           expect($('link[href="style.css"]').toString()).toBe('<link href="style.css" rel="stylesheet">');
           expect($('link[href="foo.css"]').toString()).toBe('<link href="foo.css" rel="stylesheet">');
           expect($('link[href="bar.css"]').toString()).toBe('<link href="bar.css" rel="stylesheet">');
+          expect($('link[href="baz.css"]').toString()).toBe('<link href="baz.css" rel="stylesheet">');
           expect($($('link').get(1)).toString()).toBe('<link href="foo.css" rel="stylesheet">');
           expect($($('link').get(2)).toString()).toBe('<link href="bar.css" rel="stylesheet">');
+          expect($($('link').get(3)).toString()).toBe('<link href="baz.css" rel="stylesheet">');
           done();
         });
       });
@@ -575,7 +593,18 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
         plugins: [
           new ExtractTextPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
-          new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.js', 'foo.css', { path: 'baz', type: 'css' }, 'bar.js', 'bar.css', { path: 'qux', type: 'js' }], append: true, publicPath: false })
+          new HtmlWebpackIncludeAssetsPlugin({
+            assets: [
+              'foo.js',
+              'foo.css',
+              { path: 'baz', type: 'css' },
+              { path: 'bar.js' },
+              'bar.css',
+              { path: 'qux', type: 'js' }
+            ],
+            append: true,
+            publicPath: false
+          })
         ]
       }, function (err, result) {
         expect(err).toBeFalsy();

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -76,14 +76,6 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
       done();
     });
 
-    it('should throw an error if any of the asset options are objects missing the type property', function (done) {
-      var theFunction = function () {
-        return new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.js', { path: 'baz.js' }, 'bar.css'], append: false });
-      };
-      expect(theFunction).toThrowError(/(options assets key array objects must contain a string type property)/);
-      done();
-    });
-
     it('should throw an error if any of the asset options are objects with an invalid type property', function (done) {
       var theFunction = function () {
         return new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.js', { path: 'baz.js', type: 'foo' }, 'bar.css'], append: false });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -43,7 +43,7 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
       done();
     });
 
-    it('should throw an error if the assets are not an array or string', function (done) {
+    it('should throw an error if the assets are not an array or string or object', function (done) {
       var theFunction = function () {
         return new HtmlWebpackIncludeAssetsPlugin({ assets: 123, append: false });
       };
@@ -63,6 +63,14 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
     it('should throw an error if any of the asset options are objects missing the path property', function (done) {
       var theFunction = function () {
         return new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.js', { type: 'js' }, 'bar.css'], append: false });
+      };
+      expect(theFunction).toThrowError(/(options assets key array objects must contain a string path property)/);
+      done();
+    });
+
+    it('should throw an error if any of the asset options are objects with a path property that is not a string', function (done) {
+      var theFunction = function () {
+        return new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.js', { path: 123, type: 'js' }, 'bar.css'], append: false });
       };
       expect(theFunction).toThrowError(/(options assets key array objects must contain a string path property)/);
       done();


### PR DESCRIPTION
This is to solve edge cases where you want to include an asset that doesn't have a typical file extension (which can be common when loading assets over CDNs, particularly Google Fonts).

It allows users to manually specify the type of each asset by passing an object instead of a string.

For example:

```javascript
plugins: [
  new CopyWebpackPlugin([
    { from: 'node_modules/bootstrap/dist/css', to: 'css/'},
    { from: 'node_modules/bootstrap/dist/fonts', to: 'fonts/'}
  ]),
  new HtmlWebpackPlugin(),
  new HtmlWebpackIncludeAssetsPlugin({
    assets: [
      '/css/bootstrap.min.css',
      '/css/bootstrap-theme.min.css',
      // No file extension on URL, manually specify with `type: 'css'`
      { path: 'https://fonts.googleapis.com/css?family=Material+Icons', type: 'css' }
    ],
    append: false,
    publicPath: ''
  })
]
```