### PR TITLE
Fix Windows path normalization for web URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,15 @@ function hasExtensions (v, extensions) {
   return found;
 }
 
+function normalizePath (input) {
+  var isExtendedLengthPath = /^\\\\\?\\/.test(input);
+  var hasNonAscii = /[^\u0000-\u0080]+/.test(input);
+  if (isExtendedLengthPath || hasNonAscii) {
+    return input;
+  }
+  return input.replace(/\\/g, '/');
+}
+
 function isOneOf (v, values) {
   return values.indexOf(v) !== -1;
 }
@@ -252,7 +261,7 @@ HtmlWebpackIncludeAssetsPlugin.prototype.apply = function (compiler) {
 
             // assets will be an array of strings with all matching asset file names
             includeAssetPaths = glob.sync(includeAsset.glob, globOptions).map(
-              function (globAsset) { return path.join(includeAsset.path, globAsset); });
+              function (globAsset) { return normalizePath(path.join(includeAsset.path, globAsset)); });
           }
         } else {
           includeAssetType = null;


### PR DESCRIPTION
Hi @jharris4, thanks for you work! Keep going with thus plugin :P

---

When using `html-webpack-include-assets-plugin` under Windows, it gives you URLs like:
`href="/static\css\custom.css"`

![Before](https://user-images.githubusercontent.com/5501615/31797531-5d510dfa-b537-11e7-9a26-e868eb564f62.png)

Now this behavior in the past, this PR fixes paths by correct noramilizing it into:
`href="/static/css/custom.css"`

![After](https://user-images.githubusercontent.com/5501615/31797546-71ab0f3a-b537-11e7-9057-3811d1ea8168.png)
