### PR TITLE
Make webpack  4 compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,7 +281,12 @@ HtmlWebpackIncludeAssetsPlugin.prototype.apply = function (compiler) {
         assets.js = jsAssets.concat(assets.js);
         assets.css = cssAssets.concat(assets.css);
       }
-      callback(null, htmlPluginData);
+
+      if (callback) {
+        callback(null, htmlPluginData);
+      } else {
+        return Promise.resolve(htmlPluginData);
+      }
     });
 
     compilation.plugin('html-webpack-plugin-alter-asset-tags', function (htmlPluginData, callback) {
@@ -304,7 +309,11 @@ HtmlWebpackIncludeAssetsPlugin.prototype.apply = function (compiler) {
       };
 
       if (shouldSkip(htmlPluginData)) {
-        return callback(null, htmlPluginData);
+        if (callback) {
+          callback(null, htmlPluginData);
+        } else {
+          return Promise.resolve(htmlPluginData);
+        }
       }
 
       tags = htmlPluginData.head.concat(htmlPluginData.body);
@@ -317,7 +326,11 @@ HtmlWebpackIncludeAssetsPlugin.prototype.apply = function (compiler) {
         }
       }
 
-      callback(null, htmlPluginData);
+      if (callback) {
+        callback(null, htmlPluginData);
+      } else {
+        return Promise.resolve(htmlPluginData);
+      }
     });
   });
 };


### PR DESCRIPTION
Based on webpack 4 fix for html-webpack-exclude-assets-plugin
See commit [b9d7c14597](https://github.com/jamesjieye/html-webpack-exclude-assets-plugin/commit/b9d7c14597fa0566f6b66a8df1a33df30cb7b316)