### PR TITLE
Webpack 4 & HtmlWebpackPlugin 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "7"
+  - "8"
+  - "10"
 script:
   - npm test

--- a/index.js
+++ b/index.js
@@ -255,11 +255,11 @@ HtmlWebpackIncludeAssetsPlugin.prototype.apply = function (compiler) {
 
             var globOptions = {cwd: cwd};
 
-                    // assets will be an array of strings with all matching asset file names
+            // assets will be an array of strings with all matching asset file names
             includeAssetPaths = glob.sync(includeAsset.glob, globOptions).map(
-                        function (globAsset) {
-                          return slash(path.join(includeAsset.path, globAsset));
-                        });
+              function (globAsset) {
+                return slash(path.join(includeAsset.path, globAsset));
+              });
           }
         } else {
           includeAssetType = null;
@@ -344,7 +344,7 @@ HtmlWebpackIncludeAssetsPlugin.prototype.apply = function (compiler) {
       compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration.tapAsync('htmlWebpackIncludeAssetsPlugin', onBeforeHtmlGeneration);
       compilation.hooks.htmlWebpackPluginAlterAssetTags.tapAsync('htmlWebpackIncludeAssetsPlugin', onAlterAssetTag);
     } else {
-        // Webpack 3
+      // Webpack 3
       compilation.plugin('html-webpack-plugin-before-html-generation', onBeforeHtmlGeneration);
       compilation.plugin('html-webpack-plugin-alter-asset-tags', onAlterAssetTag);
     }

--- a/index.js
+++ b/index.js
@@ -322,7 +322,13 @@ HtmlWebpackIncludeAssetsPlugin.prototype.apply = function (compiler) {
         }
       }
 
-      tags = htmlPluginData.head.concat(htmlPluginData.body);
+      // HtmlWebpackPlugin 3.x
+      if (htmlPluginData.head) {
+        tags = htmlPluginData.head.concat(htmlPluginData.body);
+      } else {
+        // HtmlWebpackPlugin 4.x
+        tags = htmlPluginData.headTags.concat(htmlPluginData.bodyTags);
+      }
       tagCount = tags.length;
       for (var i = 0; i < tagCount; i++) {
         tag = tags[i];
@@ -341,8 +347,17 @@ HtmlWebpackIncludeAssetsPlugin.prototype.apply = function (compiler) {
 
     // Webpack 4+
     if (compilation.hooks) {
-      compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration.tapAsync('htmlWebpackIncludeAssetsPlugin', onBeforeHtmlGeneration);
-      compilation.hooks.htmlWebpackPluginAlterAssetTags.tapAsync('htmlWebpackIncludeAssetsPlugin', onAlterAssetTag);
+      // HtmlWebPackPlugin 3.x
+      if (compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration) {
+        compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration.tapAsync('htmlWebpackIncludeAssetsPlugin', onBeforeHtmlGeneration);
+        compilation.hooks.htmlWebpackPluginAlterAssetTags.tapAsync('htmlWebpackIncludeAssetsPlugin', onAlterAssetTag);
+      } else {
+        // HtmlWebPackPlugin 4.x
+        var HtmlWebpackPlugin = require('html-webpack-plugin');
+        var hooks = HtmlWebpackPlugin.getHooks(compilation);
+        hooks.beforeAssetTagGeneration.tapAsync('htmlWebpackIncludeAssetsPlugin', onBeforeHtmlGeneration);
+        hooks.alterAssetTagGroups.tapAsync('htmlWebpackIncludeAssetsPlugin', onAlterAssetTag);
+      }
     } else {
       // Webpack 3
       compilation.plugin('html-webpack-plugin-before-html-generation', onBeforeHtmlGeneration);

--- a/package.json
+++ b/package.json
@@ -31,19 +31,19 @@
   "homepage": "https://github.com/jharris4/html-webpack-include-assets-plugin",
   "devDependencies": {
     "cheerio": "^1.0.0-rc.2",
-    "copy-webpack-plugin": "^4.0.1",
-    "css-loader": "^0.28.7",
-    "extract-text-webpack-plugin": "^3.0.0",
-    "html-webpack-plugin": "^2.30.1",
-    "jasmine": "^2.8.0",
+    "copy-webpack-plugin": "^4.5.2",
+    "css-loader": "^1.0.0",
+    "html-webpack-plugin": "^3.2.0",
+    "jasmine": "^3.2.0",
+    "mini-css-extract-plugin": "^0.4.3",
     "rimraf": "^2.6.2",
-    "semistandard": "^11.0.0",
-    "style-loader": "^0.18.2",
-    "webpack": "^3.6.0"
+    "semistandard": "^12.0.1",
+    "style-loader": "^0.23.0",
+    "webpack": "^4.19.1"
   },
   "dependencies": {
-    "glob": "^7.1.2",
+    "glob": "^7.1.3",
     "minimatch": "^3.0.4",
-    "slash": "^1.0.0"
+    "slash": "^2.0.0"
   }
 }

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var cheerio = require('cheerio');
 var webpack = require('webpack');
 var rimraf = require('rimraf');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var MiniCssExtractPlugin = require('mini-css-extract-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var HtmlWebpackIncludeAssetsPlugin = require('../');
@@ -275,10 +275,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: 'foobar.js', append: true, publicPath: false })
         ]
@@ -312,10 +312,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: 'foobar.css', append: true, publicPath: false })
         ]
@@ -349,10 +349,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: 'foobar.js', append: false, publicPath: false })
         ]
@@ -386,10 +386,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: 'foobar.css', append: false, publicPath: false })
         ]
@@ -423,10 +423,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.css', 'foo.js'], append: false, publicPath: false, debug: true }),
           new HtmlWebpackIncludeAssetsPlugin({ assets: ['bar.css', 'bar.js'], append: true, publicPath: false, debug: true })
@@ -467,10 +467,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.css', 'bar.css', { path: 'baz.css' }], append: true, publicPath: false })
         ]
@@ -508,10 +508,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.css', 'bar.css'], append: false, publicPath: false })
         ]
@@ -549,10 +549,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({
             files: ['fail.html'],
@@ -589,10 +589,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({
             files: ['*.html'],
@@ -633,10 +633,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: [], append: true })
         ]
@@ -668,10 +668,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({
             assets: [
@@ -722,10 +722,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.js', 'foo.jsx'], append: true, jsExtensions: ['.js', '.jsx'] })
         ]
@@ -761,10 +761,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: ['foo.css', 'foo.style'], append: true, cssExtensions: ['.css', '.style'] })
         ]
@@ -800,10 +800,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: [{ path: 'assets/', globPath: 'spec/fixtures/', glob: 'nonexistant*.js' }, { path: 'assets/', globPath: 'spec/fixtures/', glob: 'nonexistant*.css' }], append: true })
         ]
@@ -835,10 +835,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new CopyWebpackPlugin([{ from: 'spec/fixtures/g*', to: 'assets/', flatten: true }]),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: [{ path: 'assets/', globPath: 'spec/fixtures/', glob: 'g*.js' }, { path: 'assets/', globPath: 'spec/fixtures/', glob: 'g*.css' }], append: true })
@@ -875,10 +875,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: [{ path: 'assets/abc.js', attributes: { id: 'abc' } }, { path: 'assets/def.css', attributes: { id: 'def', media: 'screen' } }, { path: 'assets/ghi.css' }], append: false })
         ]
@@ -919,10 +919,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           filename: '[name].js'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin({ hash: true }),
           new HtmlWebpackIncludeAssetsPlugin({ assets: [{ path: 'assets/abc.js', attributes: { id: 'abc' } }, { path: 'assets/def.css', attributes: { id: 'def', media: 'screen' } }, { path: 'assets/ghi.css' }], append: false, hash: true })
         ]
@@ -961,10 +961,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           publicPath: 'thePublicPath'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: 'foobar.js', append: false, publicPath: true })
         ]
@@ -999,10 +999,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           publicPath: 'thePublicPath'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin(
             { assets: 'local-with-public-path.js', append: false, publicPath: true }
@@ -1046,10 +1046,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           publicPath: 'thePublicPath'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin(),
           new HtmlWebpackIncludeAssetsPlugin({ assets: 'foobar.js', append: false, publicPath: 'abc/' })
         ]
@@ -1086,10 +1086,10 @@ describe('HtmlWebpackIncludeAssetsPlugin', function () {
           publicPath: 'myPublic'
         },
         module: {
-          loaders: [{ test: /\.css$/, loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' }) }]
+          rules: [{ test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }]
         },
         plugins: [
-          new ExtractTextPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].css' }),
           new HtmlWebpackPlugin({ hash: true })
         ]
       };


### PR DESCRIPTION
Update the package dependencies from webpack 3.x to webpack 4.x

Drop node 4 support

Add support (backwards compatible) for html-webpack-plugin 4.x